### PR TITLE
https://www.acmicpc.net/problem/1354

### DIFF
--- a/minor7295/1354.java
+++ b/minor7295/1354.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+public class Main {
+    static long n;
+    static long p;
+    static long q;
+    static long x;
+    static long y;
+
+    static final HashMap<Long, Long> memo = new HashMap<>();
+
+    static long solve(long i) {
+        if (i <= 0) {
+            return 1L;
+        }
+
+        Long cached = memo.get(i);
+        if (cached != null) {
+            return cached;
+        }
+
+        long value = solve(i / p - x) + solve(i / q - y);
+        memo.put(i, value);
+        return value;
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Long.parseLong(st.nextToken());
+        p = Long.parseLong(st.nextToken());
+        q = Long.parseLong(st.nextToken());
+        x = Long.parseLong(st.nextToken());
+        y = Long.parseLong(st.nextToken());
+
+        System.out.println(solve(n));
+    }
+}


### PR DESCRIPTION
## Summary

`dynamic-programming/boj-1354` 폴더를 추가하고 BOJ 1354 무한 수열 2를 **메모이제이션 재귀(Top-down DP)**로 구현했습니다. 이번 구현은 점화식을 그대로 따르되, 큰 입력(`N <= 10^13`)에서도 동작하도록 필요한 상태만 계산하는 방식으로 정리한 것이 핵심입니다.

## 주요 판단 및 구현 흐름

### 1) `A_1`을 먼저 확인해 전개가 닫히는지 검증

예시 `N=12, P=2, Q=3, X=1, Y=0`에서  
`A_1 = A_(floor(1/2)-1) + A_(floor(1/3)-0) = A_-1 + A_0 = 2`가 바로 성립합니다.  
즉 식이 `i <= 0` 기저로 닫힌다는 것을 먼저 확인했습니다.

### 2) 상위 항 전개에서 반복 상태를 확인

같은 예시를 펼치면  
`A_12 = A_5 + A_4`, `A_5 = A_1 + A_1`, `A_4 = A_1 + A_1`이므로 `A_12 = 4 * A_1 = 8`입니다.  
이 과정에서 `A_1`처럼 같은 상태가 반복 호출된다는 점이 드러납니다.

### 3) 점프형 점화식이므로 Top-down을 선택

이 문제는 `A_i`가 `A_(floor(i / P) - X)`, `A_(floor(i / Q) - Y)`를 참조하는 점프형 구조입니다.  
`n -> n+1` 순차 채움보다 재귀 분해가 구조적으로 맞고, `N`이 매우 커서 배열 DP는 배제했습니다.

### 4) 구현에서 상태 표현과 계산 순서를 고정

구현은 점화식을 그대로 옮겼습니다. `i <= 0`이면 1을 반환하고, 이미 계산한 `i`는 캐시에서 즉시 반환하며, 처음 보는 상태만 좌/우 하위 문제를 계산해 합산 후 저장합니다.  
상태 표현은 `memo[i] = A_i`로 두어 `HashMap`이 계산된 항의 값 테이블 역할을 하도록 했습니다.

```java
static long solve(long i) {
    if (i <= 0) return 1L;

    Long cached = memo.get(i);
    if (cached != null) return cached;

    long left = solve(i / p - x);
    long right = solve(i / q - y);
    long value = left + right;

    memo.put(i, value);
    return value;
}
```

## 시간 복잡도 및 공간 복잡도

### 시간 복잡도: `O(U)`
- `U`: 실제 방문한 서로 다른 인덱스 수
- 각 상태는 캐시로 최대 1회 계산

### 공간 복잡도: `O(U)`
- `HashMap`에 저장된 상태 수에 비례
